### PR TITLE
Update refine-prd model to claude-opus-4-1-20250805

### DIFF
--- a/commands/refine-prd.md
+++ b/commands/refine-prd.md
@@ -3,7 +3,7 @@ name: refine-prd
 description: Advanced PRD command that will ask the user questions to fill in gaps on the provided PRD.  This process will update the PRD with the answered questions.
 usage: /fold-prompt {link to prd document}
 allowed-tools: Read, Edit, Glob, Grep
-model: opus
+model: claude-opus-4-1-20250805
 ---
 
  ## Mission


### PR DESCRIPTION
This PR updates the model specification in the refine-prd command from 'opus' to 'claude-opus-4-1-20250805' to use the latest Claude model version.

## Changes
- Updated model field in commands/refine-prd.md from 'opus' to 'claude-opus-4-1-20250805'

## Impact
- The refine-prd command will now use the updated Claude model version
- No functional changes to the command behavior