### PR TITLE
fix: correct installer directories and YAML parsing issues

### DIFF
--- a/agents/yaml/ai-mesh-orchestrator.yaml
+++ b/agents/yaml/ai-mesh-orchestrator.yaml
@@ -395,22 +395,22 @@ delegationCriteria:
 
     - agent: backend-developer
       triggers:
-        - **ALL backend implementation work** (Phoenix, Rails, .NET, NestJS, or any backend framework)
-        - Rails-specific: ActiveRecord models, migrations, associations, API controllers, background jobs (dynamically loads skills/rails-framework/)
-        - Phoenix-specific: LiveView, Ecto, PubSub, GenServer, OTP patterns (dynamically loads skills/phoenix-framework/)
-        - .NET-specific: ASP.NET Core, Wolverine, MartenDB, event sourcing (dynamically loads skills/dotnet-framework/)
-        - NestJS-specific: TypeScript services, dependency injection, modules, providers (dynamically loads skills/nestjs-framework/)
-        - Framework-agnostic: Clean architecture, RESTful APIs, database integration
-        - **Agent automatically detects framework** from project files (mix.exs, Gemfile, *.csproj, package.json) and loads appropriate skills
+        - '**ALL backend implementation work** (Phoenix, Rails, .NET, NestJS, or any backend framework)'
+        - 'Rails-specific: ActiveRecord models, migrations, associations, API controllers, background jobs (dynamically loads skills/rails-framework/)'
+        - 'Phoenix-specific: LiveView, Ecto, PubSub, GenServer, OTP patterns (dynamically loads skills/phoenix-framework/)'
+        - '.NET-specific: ASP.NET Core, Wolverine, MartenDB, event sourcing (dynamically loads skills/dotnet-framework/)'
+        - 'NestJS-specific: TypeScript services, dependency injection, modules, providers (dynamically loads skills/nestjs-framework/)'
+        - 'Framework-agnostic: Clean architecture, RESTful APIs, database integration'
+        - '**Agent automatically detects framework** from project files (mix.exs, Gemfile, *.csproj, package.json) and loads appropriate skills'
 
     - agent: frontend-developer
       triggers:
-        - **ALL frontend implementation work** (React, Blazor, Vue, Angular, Svelte, or any frontend framework)
-        - React-specific: Hooks, Context, state management, component patterns (dynamically loads skills/react-framework/)
-        - Blazor-specific: Blazor Server/WebAssembly, Fluent UI, SignalR, .razor components (dynamically loads skills/blazor-framework/)
-        - Vue/Angular/Svelte: Framework-specific patterns as needed
-        - Framework-agnostic: Accessibility (WCAG 2.1 AA), responsive design, performance optimization, Core Web Vitals
-        - **Agent automatically detects framework** from project files (package.json, *.csproj, .jsx/.tsx, .razor) and loads appropriate skills
+        - '**ALL frontend implementation work** (React, Blazor, Vue, Angular, Svelte, or any frontend framework)'
+        - 'React-specific: Hooks, Context, state management, component patterns (dynamically loads skills/react-framework/)'
+        - 'Blazor-specific: Blazor Server/WebAssembly, Fluent UI, SignalR, .razor components (dynamically loads skills/blazor-framework/)'
+        - 'Vue/Angular/Svelte: Framework-specific patterns as needed'
+        - 'Framework-agnostic: Accessibility (WCAG 2.1 AA), responsive design, performance optimization, Core Web Vitals'
+        - '**Agent automatically detects framework** from project files (package.json, *.csproj, .jsx/.tsx, .razor) and loads appropriate skills'
 
     - agent: infrastructure-specialist
       triggers:

--- a/install.sh
+++ b/install.sh
@@ -205,7 +205,7 @@ echo -e "${GREEN}═════════════════════
 echo ""
 
 # Execute the local Node.js installer
-NODE_INSTALLER="$SCRIPT_DIR/bin/claude-installer"
+NODE_INSTALLER="$SCRIPT_DIR/bin/ai-mesh"
 
 if [ ! -f "$NODE_INSTALLER" ]; then
 	log_error "Node.js installer not found at: $NODE_INSTALLER"

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -428,18 +428,21 @@ case '-t':
     this.logger.info('🔍 Validating Claude Configuration...');
 
     const options = this.parseInstallOptions(args);
+    
+    // Determine tool if not specified
+    const tool = options.tool || 'claude';
 
     // Try to detect which installation exists, or use specified scope
     let installPath;
     if (options.scope) {
-      installPath = this.getInstallPath(options.scope);
+      installPath = this.getInstallPath(options.scope, tool);
     } else {
       // Check local first, then global
-      const localPath = this.getInstallPath('local');
-      const globalPath = this.getInstallPath('global');
+      const localPath = this.getInstallPath('local', tool);
+      const globalPath = this.getInstallPath('global', tool);
 
-      const localValidation = await this.validator.validateInstallation(localPath);
-      const globalValidation = await this.validator.validateInstallation(globalPath);
+      const localValidation = await this.validator.validateInstallation(localPath, tool);
+      const globalValidation = await this.validator.validateInstallation(globalPath, tool);
 
       if (localValidation.success) {
         installPath = localPath;
@@ -453,11 +456,11 @@ case '-t':
       }
     }
 
-    const validation = await this.validator.validateInstallation(installPath);
+    const validation = await this.validator.validateInstallation(installPath, tool);
 
     if (validation.success) {
       this.logger.success('✅ Installation is valid and working correctly!');
-      this.logger.info(`📁 Installation path: ${installPath.claude}`);
+      this.logger.info(`📁 Installation path: ${installPath[tool]}`);
     } else {
       this.logger.error('❌ Validation failed:');
       validation.errors.forEach(error => this.logger.error(`  • ${error}`));

--- a/src/installer/agent-installer.js
+++ b/src/installer/agent-installer.js
@@ -20,7 +20,7 @@ class AgentInstaller {
     this.logger.info('📁 Installing agents...');
     
     const yamlDir = path.join(__dirname, '../../agents/yaml');
-    const targetDir = path.join(this.installPath[tool], 'agent');
+    const targetDir = path.join(this.installPath[tool], 'agents');
     
     await fs.mkdir(targetDir, { recursive: true });
     

--- a/src/installer/command-installer.js
+++ b/src/installer/command-installer.js
@@ -20,7 +20,7 @@ class CommandInstaller {
     this.logger.info('⚡ Installing commands...');
     
     const yamlDir = path.join(__dirname, '../../commands/yaml');
-    const targetDir = path.join(this.installPath[tool], 'command');
+    const targetDir = path.join(this.installPath[tool], 'commands');
     
     await fs.mkdir(targetDir, { recursive: true });
     

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -163,8 +163,8 @@ class Validator {
         return results;
       }
 
-      // Check subdirectories (singular form for agent/command)
-      const subdirs = ['agent', 'command'];
+      // Check subdirectories (plural form for agents/commands)
+      const subdirs = ['agents', 'commands'];
       for (const subdir of subdirs) {
         const subdirPath = path.join(claudePath, subdir);
         const subdirExists = await this.fileExists(subdirPath);
@@ -172,8 +172,7 @@ class Validator {
         if (subdirExists) {
           const files = await fs.readdir(subdirPath);
           const count = files.filter(f => f.endsWith('.md') || f.endsWith('.txt') || f.endsWith('.js')).length;
-          const pluralKey = subdir + 's';
-          results[pluralKey] = count;
+          results[subdir] = count;
         } else {
           results.valid = false;
           results.errors.push(`${subdir} directory not found`);
@@ -306,8 +305,8 @@ class Validator {
         return false;
       }
 
-      const agentPath = path.join(toolPath, 'agent');
-      const commandPath = path.join(toolPath, 'command');
+      const agentPath = path.join(toolPath, 'agents');
+      const commandPath = path.join(toolPath, 'commands');
       
       const agentExists = await this.fileExists(agentPath);
       const commandExists = await this.fileExists(commandPath);


### PR DESCRIPTION
## Summary
Fixes critical installer bugs that prevented proper installation and Claude Code integration.

## Changes
- **YAML Parsing**: Fixed ai-mesh-orchestrator.yaml by quoting strings with special characters (`**`, `:`) that were causing YAML alias interpretation errors
- **Directory Structure**: Changed installer to use correct plural directory names (`agents/` and `commands/`) instead of singular forms
- **Validator Updates**: Updated validation logic to check for plural directories
- **Installation Detection**: Fixed validate command to properly detect existing installations with correct tool parameter
- **Install Script**: Updated install.sh to reference correct bin path (ai-mesh)

## Files Changed
- `agents/yaml/ai-mesh-orchestrator.yaml`: Quote trigger strings to prevent YAML alias interpretation
- `src/installer/agent-installer.js`: Install to 'agents' directory (plural)
- `src/installer/command-installer.js`: Install to 'commands' directory (plural)
- `src/utils/validator.js`: Check for plural directory names
- `src/cli/index.js`: Add missing tool parameter in validate command
- `install.sh`: Update NODE_INSTALLER path to bin/ai-mesh

## Impact
- Fixes installation validation failures
- Ensures Claude Code compatibility by using standard directory structure
- Resolves YAML parsing errors during installation

## Testing
- Verified YAML parsing succeeds without errors
- Confirmed installation to correct directories (~/.claude/agents/ and ~/.claude/commands/)
- Validated installation detection works correctly
- Tested that Claude Code can find agents and commands in plural directories
